### PR TITLE
Get kpts and descriptions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ device = 'cuda' # 'cpu'
 img0 = matcher.image_loader('path/to/img0.png', resize=img_size)
 img1 = matcher.image_loader('path/to/img1.png', resize=img_size)
 
-num_inliers, H, mkpts0, mkpts1 = matcher(img0, img1, device=device)
+result = matcher(img0, img1, device=device)
+num_inliers, H, mkpts0, mkpts1 = result['num_inliers'], result['H'], result['mkpts0'], result['mkpts1']
+# result.keys() = ['num_inliers', 'H', 'mkpts0', 'mkpts1', 'inliers0', 'inliers1', 'kpts0', 'kpts1', 'desc0', 'desc1']
+
 ```
 
 You can also run as a standalone script, which will perform inference on the the examples inside `./assets`. It is possible to specify also resolution and num_keypoints. This will take a few seconds also on a laptop's CPU, and will produce the same images that you see above.

--- a/main.py
+++ b/main.py
@@ -30,7 +30,8 @@ def main(args):
         image0 = matcher.image_loader(img0_path, resize=image_size).to(args.device)
         image1 = matcher.image_loader(img1_path, resize=image_size).to(args.device)
         with torch.inference_mode():
-            num_inliers, fm, mkpts0, mkpts1 = matcher(image0, image1)
+            result = matcher(image0, image1)
+            num_inliers, H, mkpts0, mkpts1 = result['num_inliers'], result['H'], result['mkpts0'], result['mkpts1']
         out_str = f'Paths: {str(img0_path), str(img1_path)}. Found {num_inliers} inliers after RANSAC. '
         
         if not args.no_viz:
@@ -43,7 +44,7 @@ def main(args):
         
         dict_path = (args.out_dir / f'output_{i}.torch')
         output_dict = {
-            'num_inliers': num_inliers, 'fm': fm, 'mkpts0': mkpts0, 'mkpts1': mkpts1,
+            'num_inliers': num_inliers, 'H': H, 'mkpts0': mkpts0, 'mkpts1': mkpts1,
             'img0_path': img0_path, 'img1_path': img1_path, 'matcher': args.matcher,
             'n_kpts': args.n_kpts, 'im_size': args.im_size
         }

--- a/matching/__init__.py
+++ b/matching/__init__.py
@@ -9,6 +9,7 @@ import sys
 sys.path.append('third_party/LightGlue')
 from lightglue import viz2d # for quick import later 'from matching import viz2d'
 from pathlib import Path
+from util import to_numpy
 
 WEIGHTS_DIR = Path(__file__).parent.parent.joinpath('model_weights')
 WEIGHTS_DIR.mkdir(exist_ok=True)

--- a/matching/base_matcher.py
+++ b/matching/base_matcher.py
@@ -45,6 +45,30 @@ class BaseMatcher(torch.nn.Module):
         num_inliers = inliers_mask.sum()
 
         return num_inliers, H, mkpts0, mkpts1
+    
+    def get_descriptors(self):
+        """
+        Get all features/descriptors for img0, img1. 
+        
+        Must be implemented in child class.
+
+        Returns
+        -------
+        (desc0, desc1): tuple of keypoints for img0, img1 
+        """
+        return NotImplementedError
+    
+    def get_kpts(self):
+        """
+        Get all keypoints for img0, img1. 
+        
+        Must be implemented in child class.
+
+        Returns
+        -------
+        (kpts0, kpts1): tuple of keypoints for img0, img1 
+        """
+        return NotImplementedError    
         
     @torch.inference_mode()
     def forward(self, img0, img1):

--- a/matching/base_matcher.py
+++ b/matching/base_matcher.py
@@ -40,35 +40,12 @@ class BaseMatcher(torch.nn.Module):
             return 0, None, mkpts0, mkpts1
 
         H, inliers_mask = self.find_homography(mkpts0, mkpts1)
-        mkpts0 = mkpts0[inliers_mask]
-        mkpts1 = mkpts1[inliers_mask]
+        inlier_mkpts0 = mkpts0[inliers_mask]
+        inlier_mkpts1 = mkpts1[inliers_mask]
         num_inliers = inliers_mask.sum()
 
-        return num_inliers, H, mkpts0, mkpts1
+        return num_inliers, H, inlier_mkpts0, inlier_mkpts1
     
-    def get_descriptors(self):
-        """
-        Get all features/descriptors for img0, img1. 
-        
-        Must be implemented in child class.
-
-        Returns
-        -------
-        (desc0, desc1): tuple of keypoints for img0, img1 
-        """
-        return NotImplementedError
-    
-    def get_kpts(self):
-        """
-        Get all keypoints for img0, img1. 
-        
-        Must be implemented in child class.
-
-        Returns
-        -------
-        (kpts0, kpts1): tuple of keypoints for img0, img1 
-        """
-        return NotImplementedError    
         
     @torch.inference_mode()
     def forward(self, img0, img1):

--- a/matching/base_matcher.py
+++ b/matching/base_matcher.py
@@ -59,10 +59,18 @@ class BaseMatcher(torch.nn.Module):
 
         Returns
         -------
+        dict with keys: ['num_inliers', 'H', 'mkpts0', 'mkpts1', 'inliers0', 'inliers1', 'kpts0', 'kpts1', 'desc0', 'desc1']
+        
         num_inliers : int, number of inliers after RANSAC, i.e. num(mkpts0)
         H : np.array (3 x 3), the homography matrix to map mkpts0 to mkpts1
-        mkpts0 : torch.tensor (N x 2), keypoints from img0 that match mkpts1
-        mkpts1 : torch.tensor (N x 2), keypoints from img1 that match mkpts0
+        mkpts0 : np.ndarray (N x 2), keypoints from img0 that match mkpts1 (pre-RANSAC)
+        mkpts1 : np.ndarray (N x 2), keypoints from img1 that match mkpts0 (pre-RANSAC)
+        inliers0 : np.ndarray (N x 2), filtered mkpts0 that fit the H model (post-RANSAC mkpts)
+        inliers1 : np.ndarray (N x 2), filtered mkpts1 that fit the H model (post-RANSAC mkpts)
+        kpts0 : np.ndarray (N x 2), all detected keypoints from img0 
+        kpts1 : np.ndarray (N x 2), all detected keypoints from img1
+        desc0 : np.ndarray (N x 2), all descriptors from img0 
+        desc1 : np.ndarray (N x 2), all descriptors from img1
         """
         # Take as input a pair of images (not a batch)
         assert isinstance(img0, torch.Tensor)

--- a/matching/duster.py
+++ b/matching/duster.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import os
 import torchvision.transforms as tfm
 import torch.nn.functional as F
-
+from util import to_numpy
 
 sys.path.append(str(Path(__file__).parent.parent.joinpath('third_party/duster')))
 from dust3r.inference import inference, load_model
@@ -81,4 +81,11 @@ class DusterMatcher(BaseMatcher):
 
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints
-        return self.process_matches(mkpts0, mkpts1)
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0':inliers0, 'inliers1':inliers1,
+                'kpts0': None, 'kpts1':None, 
+                'desc0': None,'desc1': None}

--- a/matching/handcrafted.py
+++ b/matching/handcrafted.py
@@ -21,23 +21,28 @@ class HandcraftedBaseMatcher(BaseMatcher):
         im = cv2.normalize(im, None, 0, 255, cv2.NORM_MINMAX).astype('uint8')
 
         return im
+    
+    def get_descriptors(self):
+        return (self.des0, self.des1)
+    
+    def get_kpts(self):
+        return (self.kp0, self.kp1)
 
     def _forward(self, img0, img1):
         """
         "det_descr" is instantiated by the subclasses.
         """
-
         # convert tensors to numpy 255-based for OpenCV
         img0 = self.tensor_to_numpy_int(img0)
         img1 = self.tensor_to_numpy_int(img1)
 
         # find the keypoints and descriptors with SIFT
-        kp0, des0 = self.det_descr.detectAndCompute(img0, None)
-        kp1, des1 = self.det_descr.detectAndCompute(img1, None)
+        self.kp0, self.des0 = self.det_descr.detectAndCompute(img0, None)
+        self.kp1, self.des1 = self.det_descr.detectAndCompute(img1, None)
         
         # BFMatcher with default params
         bf = cv2.BFMatcher()
-        raw_matches = bf.knnMatch(des0, des1, k=2)
+        raw_matches = bf.knnMatch(self.des0, self.des1, k=2)
         
         # Apply ratio test
         good = []
@@ -47,8 +52,8 @@ class HandcraftedBaseMatcher(BaseMatcher):
         
         mkpts0, mkpts1 = [], []
         for good_match in good:
-            kpt_0 = np.array(kp0[good_match.queryIdx].pt)
-            kpt_1 = np.array(kp1[good_match.trainIdx].pt)
+            kpt_0 = np.array(self.kp0[good_match.queryIdx].pt)
+            kpt_1 = np.array(self.kp1[good_match.trainIdx].pt)
 
             mkpts0.append(kpt_0)
             mkpts1.append(kpt_1)

--- a/matching/lightglue.py
+++ b/matching/lightglue.py
@@ -4,7 +4,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent.joinpath('third_party/LightGlue')))
 from lightglue import match_pair
 from lightglue import LightGlue, SuperPoint, DISK, SIFT, ALIKED, DoGHardNet
-
+from util import to_numpy
 from matching.base_matcher import BaseMatcher
 
 class LightGlueBase(BaseMatcher):
@@ -31,16 +31,23 @@ class LightGlueBase(BaseMatcher):
         feats0, feats1, matches01 = match_pair(
             self.extractor, self.matcher, img0, img1, device=self.device
         )
-        self.kpts0, self.kpts1, matches = feats0["keypoints"], feats1["keypoints"], matches01["matches"]
+        kpts0, kpts1, matches = feats0["keypoints"], feats1["keypoints"], matches01["matches"]
 
-        self.desc0 = feats0['descriptors']
-        self.desc1 = feats1['descriptors']
+        desc0 = feats0['descriptors']
+        desc1 = feats1['descriptors']
         
-        mkpts0, mkpts1 = self.kpts0[matches[..., 0]], self.kpts1[matches[..., 1]]
+        mkpts0, mkpts1 = kpts0[matches[..., 0]], kpts1[matches[..., 1]]
         
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints
-        return self.process_matches(mkpts0, mkpts1)
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0':inliers0, 'inliers1':inliers1,
+                'kpts0':to_numpy(kpts0), 'kpts1':to_numpy(kpts1), 
+                'desc0':to_numpy(desc0),'desc1': to_numpy(desc1)}
 
 
 class SiftLightGlue(LightGlueBase):

--- a/matching/lightglue.py
+++ b/matching/lightglue.py
@@ -17,7 +17,13 @@ class LightGlueBase(BaseMatcher):
     """
     def __init__(self, device="cpu"):
         super().__init__(device)
+        
+    def get_descriptors(self):
+        return (self.desc0.cpu().numpy(), self.desc1.cpu().numpy())
     
+    def get_kpts(self):
+        return (self.kpts0.cpu().numpy(), self.kpts1.cpu().numpy())
+        
     def _forward(self, img0, img1):
         """
         "extractor" and "matcher" are instantiated by the subclasses.
@@ -25,8 +31,12 @@ class LightGlueBase(BaseMatcher):
         feats0, feats1, matches01 = match_pair(
             self.extractor, self.matcher, img0, img1, device=self.device
         )
-        kpts0, kpts1, matches = feats0["keypoints"], feats1["keypoints"], matches01["matches"]
-        mkpts0, mkpts1 = kpts0[matches[..., 0]], kpts1[matches[..., 1]]
+        self.kpts0, self.kpts1, matches = feats0["keypoints"], feats1["keypoints"], matches01["matches"]
+
+        self.desc0 = feats0['descriptors']
+        self.desc1 = feats1['descriptors']
+        
+        mkpts0, mkpts1 = self.kpts0[matches[..., 0]], self.kpts1[matches[..., 1]]
         
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints

--- a/matching/loftr.py
+++ b/matching/loftr.py
@@ -1,6 +1,6 @@
 from kornia.feature import LoFTR
 import torchvision.transforms as tfm
-import torch
+from util import to_numpy
 from matching.base_matcher import BaseMatcher
 
 
@@ -21,4 +21,11 @@ class LoftrMatcher(BaseMatcher):
 
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints
-        return self.process_matches(mkpts0, mkpts1)
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0':inliers0, 'inliers1':inliers1,
+                'kpts0':None, 'kpts1':None, 
+                'desc0':None,'desc1': None}

--- a/matching/matching_toolbox.py
+++ b/matching/matching_toolbox.py
@@ -11,6 +11,7 @@ import os
 from os.path import join
 import shutil
 import torchvision.transforms as tfm
+from util import to_numpy
 
 BASE_PATH = str(Path(__file__).parent.parent.resolve() / "third_party/imatch-toolbox")
 sys.path.append(str(Path(BASE_PATH)))
@@ -70,7 +71,14 @@ class Patch2pixMatcher(BaseMatcher):
         mkpts1 = matches[:, 2:4]
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints
-        return self.process_matches(mkpts0, mkpts1)
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0':inliers0, 'inliers1':inliers1,
+                'kpts0':None, 'kpts1':None, 
+                'desc0':None,'desc1': None}
 
 
 class SuperGluePatch2pixMatcher(BaseMatcher):
@@ -96,7 +104,6 @@ class SuperGluePatch2pixMatcher(BaseMatcher):
         self.coarse_matcher = immatch.__dict__[self.cname](cargs)
 
     def _forward(self, img0, img1):
-
         img0_gray = self.to_gray(img0).unsqueeze(0).to(self.device)
         img1_gray = self.to_gray(img1).unsqueeze(0).to(self.device)
         img0 = self.normalize(img0).unsqueeze(0).to(self.device)
@@ -114,7 +121,14 @@ class SuperGluePatch2pixMatcher(BaseMatcher):
 
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints
-        return self.process_matches(mkpts0, mkpts1)
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0':inliers0, 'inliers1':inliers1,
+                'kpts0':None, 'kpts1':None, 
+                'desc0':None,'desc1': None}
 
 
 class SuperGlueMatcher(BaseMatcher):
@@ -146,7 +160,14 @@ class SuperGlueMatcher(BaseMatcher):
         
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints
-        return self.process_matches(mkpts0, mkpts1)
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0':inliers0, 'inliers1':inliers1,
+                'kpts0':kpts0, 'kpts1':kpts1, 
+                'desc0':None,'desc1': None}
 
 
 class R2D2Matcher(BaseMatcher):
@@ -188,7 +209,14 @@ class R2D2Matcher(BaseMatcher):
 
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints
-        return self.process_matches(mkpts0, mkpts1)
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0':inliers0, 'inliers1':inliers1,
+                'kpts0':to_numpy(kpts0), 'kpts1':to_numpy(kpts1), 
+                'desc0':to_numpy(desc0),'desc1': to_numpy(desc1)}
     
 
 class D2netMatcher(BaseMatcher):
@@ -236,7 +264,14 @@ class D2netMatcher(BaseMatcher):
 
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints
-        return self.process_matches(mkpts0, mkpts1)
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0':inliers0, 'inliers1':inliers1,
+                'kpts0':kpts0, 'kpts1':kpts1, 
+                'desc0':desc0,'desc1': desc1}
 
 
 class DogAffHardNNMatcher(BaseMatcher):
@@ -259,7 +294,6 @@ class DogAffHardNNMatcher(BaseMatcher):
         return im
 
     def _forward(self, img0, img1):
-        
         # convert tensors to numpy 255-based for OpenCV
         img0 = self.tensor_to_numpy_int(img0)
         img1 = self.tensor_to_numpy_int(img1)
@@ -270,4 +304,11 @@ class DogAffHardNNMatcher(BaseMatcher):
 
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints
-        return self.process_matches(mkpts0, mkpts1)
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0':inliers0, 'inliers1':inliers1,
+                'kpts0':None, 'kpts1':None, 
+                'desc0':None,'desc1': None}

--- a/matching/roma.py
+++ b/matching/roma.py
@@ -4,6 +4,7 @@ import math
 import torch
 import torchvision.transforms as tfm
 import torch.nn.functional as F
+from util import to_numpy
 
 sys.path.append(str(Path(__file__).parent.parent.joinpath('third_party/RoMa')))
 from roma import roma_outdoor
@@ -93,4 +94,12 @@ class RomaMatcher(BaseMatcher):
 
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints
-        return self.process_matches(mkpts0, mkpts1)
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0':inliers0, 'inliers1':inliers1,
+                'kpts0':None, 'kpts1':None, # dense matcher, no kpts / descs
+                'desc0':None,'desc1': None}

--- a/matching/steerers.py
+++ b/matching/steerers.py
@@ -3,12 +3,11 @@ import urllib.request
 
 import sys
 from pathlib import Path
-import math
 import torch
 import os
 import torchvision.transforms as tfm
 import torch.nn.functional as F
-
+from util import to_numpy
 
 from matching.base_matcher import BaseMatcher
 
@@ -157,4 +156,11 @@ class SteererMatcher(BaseMatcher):
 
         # process_matches is implemented by the parent BaseMatcher, it is the
         # same for all methods, given the matched keypoints
-        return self.process_matches(mkpts0, mkpts1)
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0':inliers0, 'inliers1':inliers1,
+                'kpts0':to_numpy(keypoints_0), 'kpts1':to_numpy(keypoints_1), 
+                'desc0':to_numpy(description_0),'desc1': to_numpy(description_1)}

--- a/matching/xfeat.py
+++ b/matching/xfeat.py
@@ -3,6 +3,7 @@ from matching.base_matcher import BaseMatcher
 import sys
 import torch
 from pathlib import Path
+from util import to_numpy
 sys.path.append(str(Path(__file__).parent.parent.joinpath('third_party/accelerated_features')))
 from modules.xfeat import XFeat
 
@@ -21,4 +22,12 @@ class xFeatMatcher(BaseMatcher):
             mkpts0, mkpts1 = self.model.match_xfeat_star(img0, img1, top_k=self.max_num_keypoints)
         else:
             raise ValueError(f'unsupported mode for xfeat: {self.mode}. Must choose from ["sparse", "semi-dense"]')
-        return self.process_matches(mkpts0, mkpts1)
+        
+        mkpts0, mkpts1 = to_numpy(mkpts0), to_numpy(mkpts1)
+        num_inliers, H, inliers0, inliers1 = self.process_matches(mkpts0, mkpts1)
+        return {'num_inliers':num_inliers,
+                'H': H,
+                'mkpts0':mkpts0, 'mkpts1':mkpts1,
+                'inliers0': inliers0, 'inliers1': inliers1,
+                'kpts0':None, 'kpts1':None, 
+                'desc0':None,'desc1': None}

--- a/util.py
+++ b/util.py
@@ -26,3 +26,12 @@ def get_image_pairs_paths(inputs):
             if len(pair) != 2:
                 raise RuntimeError(f'{pair} should be a pair of paths')
     return pairs_of_paths
+
+import torch
+import numpy as np
+
+def to_numpy(x):
+    if isinstance(x, torch.Tensor):
+        return x.cpu().numpy()
+    if isinstance(x, np.ndarray):
+        return x


### PR DESCRIPTION
Add API to retrieve kpts and descriptions for last image pair matches, if available. Added API in BaseMatcher and implemented in a few subclasses.

Requires running the matching before retrieving kpts. 

Ex:
```python
from matching import get_matcher
device = 'cuda'
image_size = 512
matcher = get_matcher('aliked-lg', device=device)
img0 = matcher.image_loader('assets/example_pairs/sat2iss/photo_from_iss.jpg', resize=image_size).to(device)
img1 = matcher.image_loader('assets/example_pairs/sat2iss/satellite_img.jpg', resize=image_size).to(device)
num_inliers, H, mkpts0, mkpts1 = matcher(img0, img1)

kpts0, kpts1 = matcher.get_kpts()
desc0, desc1 = matcher.get_descriptors()
```


This is a first pass at a way to retrieve the kpts and descriptors. The downside is it stores things about the images in the matcher class and replaces it silently on each call to forward(). However it might be a nice way to add this functionality without adding additional items to be returned from forward(), and keeping the return from forward uniform for all matchers, even those without kpts. 

Let me know what you think.