### PR TITLE
add option to remove homography estimation

### DIFF
--- a/matching/__init__.py
+++ b/matching/__init__.py
@@ -65,7 +65,8 @@ def get_version(pkg):
 
 
 @supress_stdout
-def get_matcher(matcher_name="sift-lg", device="cpu", max_num_keypoints=2048, *args, **kwargs):
+def get_matcher(matcher_name="sift-lg", device="cpu", max_num_keypoints=2048, skip_homography=False, *args, **kwargs):
+    kwargs['skip_homography'] = skip_homography
     if isinstance(matcher_name, list):
         from matching.im_models.base_matcher import EnsembleMatcher
 


### PR DESCRIPTION
I believe there was no easy way to skip the homography estimation step so I quickly added it. I tested it with a few matchers and everything seems to work. 

when calling a matcher it is now possible to set a `skip_homography` flag to true. 

```
matcher = get_matcher('xfeat', device=device, skip_homography=True)
```

If set to true it returns all inliers and None for the homography matrix. 

Here is an example of all matches being retained. 

![Figure_1](https://github.com/user-attachments/assets/32908c4b-1764-43e6-895a-002d9c6a2435)

And here is the result if I don't set the skip homography to true,
![Figure_2](https://github.com/user-attachments/assets/8f3570d4-b4e5-42ad-aeee-1b3001d40e49)

As this flag is set by default to false I _believe_ it should not break any older code. 
