### PR TITLE
Fix import errors when loading multiple matchers (fixes #60)

### DIFF
--- a/vismatch/im_models/aspanformer.py
+++ b/vismatch/im_models/aspanformer.py
@@ -27,6 +27,7 @@ class AspanformerMatcher(BaseMatcher):
 
         self.download_weights(cache_dir)
 
+        add_to_path(BASE_PATH)  # ensure aspanformer's ``src`` is resolvable
         config = aspan_cfg_defaults()
         config.merge_from_file(BASE_PATH.joinpath("configs", "aspan", "outdoor", "aspan_test.py"))
         self.matcher = ASpanFormer(config=lower_config(config)["aspan"])

--- a/vismatch/im_models/edm.py
+++ b/vismatch/im_models/edm.py
@@ -7,7 +7,7 @@ from huggingface_hub import snapshot_download
 from vismatch import THIRD_PARTY_DIR, BaseMatcher
 from vismatch.utils import resize_to_divisible, add_to_path
 
-add_to_path(THIRD_PARTY_DIR.joinpath("EDM"), insert=0)
+add_to_path(THIRD_PARTY_DIR.joinpath("EDM"))
 
 from src.edm import EDM
 from src.config.default import get_cfg_defaults

--- a/vismatch/im_models/efficient_loftr.py
+++ b/vismatch/im_models/efficient_loftr.py
@@ -8,7 +8,7 @@ import torchvision.transforms as tfm
 from vismatch import THIRD_PARTY_DIR, BaseMatcher
 from vismatch.utils import resize_to_divisible, add_to_path
 
-add_to_path(THIRD_PARTY_DIR.joinpath("EfficientLoFTR"), insert=0)
+add_to_path(THIRD_PARTY_DIR.joinpath("EfficientLoFTR"))
 
 from src.loftr import LoFTR, full_default_cfg, opt_default_cfg, reparameter
 

--- a/vismatch/im_models/matchanything.py
+++ b/vismatch/im_models/matchanything.py
@@ -11,17 +11,17 @@ from vismatch.utils import add_to_path, to_device, pad_images_to_same_shape, dis
 
 # Expose the MatchAnything HF Space code (nested under imcui/third_party/MatchAnything) and its deps.
 MATCHANYTHING_DIR = THIRD_PARTY_DIR.joinpath("MatchAnything", "imcui", "third_party", "MatchAnything")
-add_to_path(MATCHANYTHING_DIR, insert=0)
+add_to_path(MATCHANYTHING_DIR)
 
-# Also add ROMA to path for its internal imports (e.g., "from roma.models import ...")
-# Use insert=0 to give it priority over other potential 'roma' modules
-ROMA_DIR = MATCHANYTHING_DIR.joinpath("third_party", "ROMA")
-add_to_path(ROMA_DIR, insert=0)
+# Add ROMA's parent so ``ROMA`` is importable as a top-level namespace package,
+# and ROMA itself so its internal ``from roma.models import ...`` works.
+add_to_path(MATCHANYTHING_DIR.joinpath("third_party"))
+add_to_path(MATCHANYTHING_DIR.joinpath("third_party", "ROMA"))
 
 from yacs.config import CfgNode as CN  # noqa: E402
 from src.loftr import LoFTR  # noqa: E402
 from src.config.default import get_cfg_defaults  # noqa: E402
-from third_party.ROMA.roma.matchanything_roma_model import MatchAnything_Model  # noqa: E402
+from ROMA.roma.matchanything_roma_model import MatchAnything_Model  # noqa: E402
 
 
 def _lower_config(yacs_cfg):
@@ -57,6 +57,9 @@ class MatchAnythingMatcher(BaseMatcher):
             disable_xformers()
 
     def _load_model(self):
+        # Ensure MatchAnything's ``src`` is resolvable even when another
+        # matcher was loaded between module import and this instantiation.
+        add_to_path(MATCHANYTHING_DIR)
         cfg = get_cfg_defaults()
         if self.variant == "eloftr":
             cfg.merge_from_file(str(MATCHANYTHING_DIR.joinpath("configs", "models", "eloftr_model.py")))

--- a/vismatch/im_models/minima.py
+++ b/vismatch/im_models/minima.py
@@ -5,7 +5,7 @@ from huggingface_hub import snapshot_download
 from vismatch import THIRD_PARTY_DIR, BaseMatcher
 from vismatch.utils import add_to_path, resize_to_divisible
 
-add_to_path(THIRD_PARTY_DIR.joinpath("MINIMA"), insert=0)
+add_to_path(THIRD_PARTY_DIR.joinpath("MINIMA"))
 add_to_path(THIRD_PARTY_DIR.joinpath("MINIMA/third_party/RoMa"))
 
 from src.utils.load_model import load_sp_lg, load_loftr, load_roma, load_xoftr

--- a/vismatch/im_models/se2loftr.py
+++ b/vismatch/im_models/se2loftr.py
@@ -6,7 +6,7 @@ from vismatch import THIRD_PARTY_DIR, BaseMatcher
 from vismatch.utils import resize_to_divisible, lower_config, add_to_path
 
 
-add_to_path(THIRD_PARTY_DIR.joinpath("Se2_LoFTR"), insert=0)
+add_to_path(THIRD_PARTY_DIR.joinpath("Se2_LoFTR"))
 from src.loftr.loftr import LoFTR
 from configs.loftr.outdoor.loftr_ds_e2_dense_8rot import cfg as rot8_cfg
 from configs.loftr.outdoor.loftr_ds_e2_dense_big import cfg as big_cfg

--- a/vismatch/im_models/topicfm.py
+++ b/vismatch/im_models/topicfm.py
@@ -6,9 +6,7 @@ from huggingface_hub import snapshot_download
 from vismatch import BaseMatcher, THIRD_PARTY_DIR
 from vismatch.utils import add_to_path, resize_to_divisible
 
-# Add TopicFM to path
 add_to_path(THIRD_PARTY_DIR.joinpath("TopicFM"))
-add_to_path(THIRD_PARTY_DIR.joinpath("TopicFM/src"))
 
 from src.models.topic_fm import TopicFM  # noqa: E402
 from src import get_model_cfg  # noqa: E402

--- a/vismatch/im_models/xoftr.py
+++ b/vismatch/im_models/xoftr.py
@@ -5,7 +5,7 @@ from huggingface_hub import snapshot_download
 from vismatch import THIRD_PARTY_DIR, BaseMatcher
 from vismatch.utils import resize_to_divisible, add_to_path
 
-add_to_path(THIRD_PARTY_DIR.joinpath("XoFTR"), insert=0)
+add_to_path(THIRD_PARTY_DIR.joinpath("XoFTR"))
 
 from src.xoftr import XoFTR
 from src.config.default import get_cfg_defaults

--- a/vismatch/im_models/zippypoint.py
+++ b/vismatch/im_models/zippypoint.py
@@ -6,7 +6,7 @@ from vismatch import BaseMatcher, THIRD_PARTY_DIR
 from vismatch.utils import add_to_path
 
 ZIPPYPOINT_PATH = THIRD_PARTY_DIR.joinpath("ZippyPoint")
-add_to_path(ZIPPYPOINT_PATH, insert=0)
+add_to_path(ZIPPYPOINT_PATH)
 
 
 class ZippyPointMatcher(BaseMatcher):

--- a/vismatch/utils.py
+++ b/vismatch/utils.py
@@ -191,7 +191,7 @@ def resize_to_divisible(img: torch.Tensor, divisible_by: int = 14) -> torch.Tens
     """Resize to be divisible by a factor. Useful for ViT based models.
 
     Args:
-        img (torch.Tensor): img as tensor, in (\*, H, W) order
+        img (torch.Tensor): img as tensor, in (*, H, W) order
         divisible_by (int, optional): factor to make sure img is divisible by. Defaults to 14.
 
     Returns:
@@ -271,7 +271,7 @@ def add_to_path(path: str | Path, **_kwargs) -> None:
             continue  # already loaded from this directory
         if not resolved.startswith(_THIRD_PARTY_DIR):
             continue  # loaded from user code / pip / stdlib — never touch it
-        # Stale module from a different third-party repo — flush it
+        # Stale module from a different vismatch/third-party repo — flush it
         for k in [k for k in sys.modules if k == name or k.startswith(name + ".")]:
             del sys.modules[k]
 

--- a/vismatch/utils.py
+++ b/vismatch/utils.py
@@ -230,20 +230,50 @@ def load_module(module_name: str, module_path: Path | str) -> None:
     spec.loader.exec_module(module)
 
 
-def add_to_path(path: str | Path, insert: int | None = None) -> None:
-    """Add input path to sys.path ($PATH), allowing for imports from the specified path
+_THIRD_PARTY_DIR = str(Path(__file__).resolve().parent / "third_party") + "/"
 
-    Args:
-        path (str | Path): path to add to sys.path
-        insert (int | None, optional): insert location / order. Defaults to None, which inserts at end of sys.path
+
+def add_to_path(path: str | Path, **_kwargs) -> None:
+    """Add *path* to the front of ``sys.path``, allowing imports from it.
+
+    Always inserts at position 0 so the most recently added directory wins.
+    Auto-detects every package and module in *path* and, if any of them are
+    already cached in ``sys.modules`` from a different vismatch third-party
+    directory, flushes the stale entries so the next import resolves correctly.
+    User code, stdlib, and pip packages are never touched.
     """
-    path = str(path)
+    path = str(Path(path).resolve())
     if path in sys.path:
         sys.path.remove(path)
-    if insert is None:
-        sys.path.append(path)
-    else:
-        sys.path.insert(insert, path)
+    sys.path.insert(0, path)
+
+    # Auto-detect and flush stale modules from other third-party repos.
+    base = Path(path).resolve()
+    if not base.is_dir():
+        return
+    prefix = str(base) + "/"
+    for child in base.iterdir():
+        # Only consider regular Python packages (dir + __init__.py) and .py modules.
+        if child.is_dir() and child.joinpath("__init__.py").is_file():
+            name = child.name
+        elif child.is_file() and child.suffix == ".py" and child.name != "__init__.py":
+            name = child.stem
+        else:
+            continue
+        mod = sys.modules.get(name)
+        if mod is None:
+            continue
+        origin = getattr(mod, "__file__", None)
+        if not origin:
+            continue  # built-in — leave it alone
+        resolved = str(Path(origin).resolve())
+        if resolved.startswith(prefix):
+            continue  # already loaded from this directory
+        if not resolved.startswith(_THIRD_PARTY_DIR):
+            continue  # loaded from user code / pip / stdlib — never touch it
+        # Stale module from a different third-party repo — flush it
+        for k in [k for k in sys.modules if k == name or k.startswith(name + ".")]:
+            del sys.modules[k]
 
 
 def get_default_device() -> str:

--- a/vismatch_extract.py
+++ b/vismatch_extract.py
@@ -37,6 +37,7 @@ def parse_args():
     parser.add_argument(
         "--matcher",
         type=str,
+        nargs="+",
         default="superpoint-lightglue",
         choices=available_models,
         metavar="MODEL",
@@ -69,7 +70,11 @@ def parse_args():
     args = parser.parse_args()
 
     if args.out_dir is None:
-        args.out_dir = Path("outputs") / args.matcher
+        if isinstance(args.matcher, list):
+            matcher_str = "_".join(args.matcher)
+        else:
+            matcher_str = args.matcher
+        args.out_dir = Path("outputs") / matcher_str
 
     return args
 

--- a/vismatch_match.py
+++ b/vismatch_match.py
@@ -40,6 +40,7 @@ def parse_args():
     parser.add_argument(
         "--matcher",
         type=str,
+        nargs="+",
         default="superpoint-lightglue",
         choices=available_models,
         metavar="MODEL",
@@ -75,7 +76,11 @@ def parse_args():
     args = parser.parse_args()
 
     if args.out_dir is None:
-        args.out_dir = Path("outputs") / args.matcher
+        if isinstance(args.matcher, list):
+            matcher_str = "_".join(args.matcher)
+        else:
+            matcher_str = args.matcher
+        args.out_dir = Path("outputs") / matcher_str
 
     return args
 


### PR DESCRIPTION
Multiple third-party repos share generic package names like `src`. Python caches the first import in `sys.modules`, so loading a second matcher silently gets the wrong module.

`add_to_path()` now scans the added directory for packages that are already cached from a different third-party directory, and flushes the stale entries. User code and pip packages are never affected.

Fixes #60