### PR TITLE
Fix vismatch[all] dependency resolution on CPython 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,10 @@ HuggingFace = "https://huggingface.co/vismatch"
 omniglue = ["tensorflow"]
 sphereglue = ["torch-geometric", "torch-cluster"]
 zippypoint = ["tensorflow>=2.15,<2.16", "keras<3", "larq>=0.12.2"]
-all = ["vismatch[omniglue, sphereglue, zippypoint]"]
+all = [
+    "vismatch[omniglue, sphereglue]",
+    'vismatch[zippypoint]; python_version < "3.12"',
+]
 docs = [
     "sphinx>=7.0",
     "sphinx-rtd-theme",


### PR DESCRIPTION
Fixes #70.

`vismatch[all]` was unsatisfiable on CPython 3.12 because it always included the `zippypoint` extra, which pins TensorFlow to `<2.16`.

TensorFlow 2.15 does not provide CPython 3.12 wheels, so dependency resolution fails when installing `vismatch[all]` on Python 3.12.

This change keeps the existing ZippyPoint constraints unchanged, but conditionally includes the `zippypoint` extra in `all` only on Python versions below 3.12.

```toml
all = [
    "vismatch[omniglue, sphereglue]",
    'vismatch[zippypoint]; python_version < "3.12"',
]
```

* On Python 3.12, `vismatch[all]` installs without attempting to resolve the incompatible ZippyPoint / TensorFlow 2.15 dependency set.
* On Python 3.11 and earlier, `vismatch[all]` continues to include ZippyPoint.


Tested successfully with:

```bash
uv venv --python 3.12
uv pip install "vismatch[all]"
```

Also tested on Python 3.11 with CUDA 12.8, confirming that the ZippyPoint extra remains included and resolves correctly.
