### PR TITLE
Add optional per-match confidence output

### DIFF
--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -9,7 +9,7 @@ Let's for example add a matcher called new_matcher.
    ```
    This command automatically modifies `.gitmodules` (you should not modify `.gitmodules` manually!), and when cloning the repository it will automatically clone also the LightGlue repo in `vismatch/third_party`.
 
-3. In `vismatch/im_models/new_matcher.py` you only need to implement the method `_forward`, which takes two image tensors as input and returns 6 objects: `[mkpts0, mkpts1, kpts0, kpts1, desc0, desc1]`. The template has more details on how to implement the class.
+3. In `vismatch/im_models/new_matcher.py` you only need to implement the method `_forward`, which takes two image tensors as input and returns 6 objects: `[mkpts0, mkpts1, kpts0, kpts1, desc0, desc1]`, or 7 if per-match confidence is available: `[mkpts0, mkpts1, kpts0, kpts1, desc0, desc1, mconf]`. The template has more details on how to implement the class.
 
 4. Open `vismatch/__init__.py` and add the model name (all lowercase) to the `available_models` list. Add an `elif` case to instantiate the class, as for the other matchers.
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -14,7 +14,8 @@ img1 = matcher.load_image("img1.jpg", resize=512)
 result = matcher(img0, img1)
 # result keys: num_inliers, H, all_kpts0, all_kpts1,
 #              all_desc0, all_desc1, matched_kpts0, matched_kpts1,
-#              inlier_kpts0, inlier_kpts1
+#              matched_confidences, inlier_kpts0, inlier_kpts1
+# matched_confidences is None if the matcher does not provide confidence.
 
 plot_matches(img0, img1, result, save_path="matches.png")
 ```

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -15,9 +15,10 @@ vismatch_match.py:
 
 import pytest
 import numpy as np
+import torch
 
 import vismatch
-from vismatch import get_matcher, available_models
+from vismatch import get_matcher, available_models, BaseMatcher
 
 
 def test_import_vismatch_main():
@@ -25,6 +26,52 @@ def test_import_vismatch_main():
     assert hasattr(vismatch, "get_matcher")
     assert hasattr(vismatch, "available_models")
     assert hasattr(vismatch, "BaseMatcher")
+
+
+class LegacyMatcher(BaseMatcher):
+    def _forward(self, img0, img1):
+        kpts = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+        empty = np.empty([0, 2])
+        return kpts, kpts, empty, empty, empty, empty
+
+
+class ConfidenceMatcher(BaseMatcher):
+    def _forward(self, img0, img1):
+        kpts = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+        empty = np.empty([0, 2])
+        confidences = torch.tensor([0.25, 0.75])
+        return kpts, kpts, empty, empty, empty, empty, confidences
+
+
+class BadConfidenceMatcher(BaseMatcher):
+    def _forward(self, img0, img1):
+        kpts = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+        empty = np.empty([0, 2])
+        confidences = np.array([0.5], dtype=np.float32)
+        return kpts, kpts, empty, empty, empty, empty, confidences
+
+
+@pytest.mark.parametrize(
+    ("matcher_cls", "expected_confidences"),
+    [
+        (LegacyMatcher, None),
+        (ConfidenceMatcher, np.array([0.25, 0.75])),
+    ],
+)
+def test_forward_matcher_confidences(test_images, matcher_cls, expected_confidences):
+    img0, img1 = test_images
+    result = matcher_cls().forward(img0, img1)
+    if expected_confidences is None:
+        assert result["matched_confidences"] is None
+    else:
+        assert isinstance(result["matched_confidences"], np.ndarray)
+        np.testing.assert_allclose(result["matched_confidences"], expected_confidences)
+
+
+def test_forward_bad_confidence_shape_fails(test_images):
+    img0, img1 = test_images
+    with pytest.raises(AssertionError):
+        BadConfidenceMatcher().forward(img0, img1)
 
 
 @pytest.mark.parametrize("model_name", available_models)
@@ -63,12 +110,17 @@ def test_forward_synthetic_images(model_name, device, test_images):
     assert "num_inliers" in result
     assert "matched_kpts0" in result
     assert "matched_kpts1" in result
+    assert "matched_confidences" in result
     assert "all_kpts0" in result
     assert "all_kpts1" in result
     assert isinstance(result["matched_kpts0"], np.ndarray)
     assert isinstance(result["matched_kpts1"], np.ndarray)
+    assert result["matched_confidences"] is None or isinstance(result["matched_confidences"], np.ndarray)
     assert result["matched_kpts0"].ndim == 2
     assert result["matched_kpts1"].ndim == 2
+    if result["matched_confidences"] is not None:
+        assert result["matched_confidences"].ndim == 1
+        assert len(result["matched_confidences"]) == len(result["matched_kpts0"])
     if result["matched_kpts0"].shape[0] > 0:
         assert result["matched_kpts0"].shape[1] == 2
         assert result["matched_kpts1"].shape[1] == 2

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -28,39 +28,22 @@ def test_import_vismatch_main():
     assert hasattr(vismatch, "BaseMatcher")
 
 
-class LegacyMatcher(BaseMatcher):
-    def _forward(self, img0, img1):
-        kpts = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
-        empty = np.empty([0, 2])
-        return kpts, kpts, empty, empty, empty, empty
-
-
-class ConfidenceMatcher(BaseMatcher):
-    def _forward(self, img0, img1):
-        kpts = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
-        empty = np.empty([0, 2])
-        confidences = torch.tensor([0.25, 0.75])
-        return kpts, kpts, empty, empty, empty, empty, confidences
-
-
-class BadConfidenceMatcher(BaseMatcher):
-    def _forward(self, img0, img1):
-        kpts = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
-        empty = np.empty([0, 2])
-        confidences = np.array([0.5], dtype=np.float32)
-        return kpts, kpts, empty, empty, empty, empty, confidences
-
-
 @pytest.mark.parametrize(
-    ("matcher_cls", "expected_confidences"),
+    ("confidences", "expected_confidences"),
     [
-        (LegacyMatcher, None),
-        (ConfidenceMatcher, np.array([0.25, 0.75])),
+        (None, None),
+        (torch.tensor([0.25, 0.75]), np.array([0.25, 0.75])),
     ],
 )
-def test_forward_matcher_confidences(test_images, matcher_cls, expected_confidences):
+def test_forward_matcher_confidences(test_images, confidences, expected_confidences):
+    class Matcher(BaseMatcher):
+        def _forward(self, img0, img1):
+            kpts = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+            empty = np.empty([0, 2])
+            return kpts, kpts, empty, empty, empty, empty, confidences
+
     img0, img1 = test_images
-    result = matcher_cls().forward(img0, img1)
+    result = Matcher().forward(img0, img1)
     if expected_confidences is None:
         assert result["matched_confidences"] is None
     else:
@@ -68,10 +51,29 @@ def test_forward_matcher_confidences(test_images, matcher_cls, expected_confiden
         np.testing.assert_allclose(result["matched_confidences"], expected_confidences)
 
 
+def test_forward_requires_confidence_slot(test_images):
+    class Matcher(BaseMatcher):
+        def _forward(self, img0, img1):
+            kpts = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+            empty = np.empty([0, 2])
+            return kpts, kpts, empty, empty, empty, empty
+
+    img0, img1 = test_images
+    with pytest.raises(ValueError, match="not enough values to unpack \\(expected 7, got 6\\)"):
+        Matcher().forward(img0, img1)
+
+
 def test_forward_bad_confidence_shape_fails(test_images):
+    class Matcher(BaseMatcher):
+        def _forward(self, img0, img1):
+            kpts = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+            empty = np.empty([0, 2])
+            confidences = np.array([0.5], dtype=np.float32)
+            return kpts, kpts, empty, empty, empty, empty, confidences
+
     img0, img1 = test_images
     with pytest.raises(AssertionError):
-        BadConfidenceMatcher().forward(img0, img1)
+        Matcher().forward(img0, img1)
 
 
 @pytest.mark.parametrize("model_name", available_models)

--- a/vismatch/TEMPLATE.py
+++ b/vismatch/TEMPLATE.py
@@ -72,6 +72,7 @@ class NewMatcher(BaseMatcher):
         Returns (np.ndarray or torch.Tensor)
         -------
         matched_kpts0, matched_kpts1 : (N, 2) matched keypoints
+        matched_confidences : (N,) per-match confidence scores (None if unavailable)
         all_kpts0, all_kpts1 : (M, 2), (K, 2) all detected keypoints (None for detector-free methods)
         all_desc0, all_desc1 : (M, D), (K, D) descriptors (None for detector-free methods)
         """
@@ -93,6 +94,7 @@ class NewMatcher(BaseMatcher):
         all_kpts1 = np.random.rand(n_kpts, 2) * np.array([[w1, h1]])
         all_desc0 = np.random.rand(n_kpts, desc_dim)
         all_desc1 = np.random.rand(n_kpts, desc_dim)
+        matched_confidences = np.random.rand(n_matches)
 
         # If preprocessing resized the image, rescale keypoints back to original size
         # H0, W0, H1, W1 = *img0.shape[-2:], *img1.shape[-2:]
@@ -100,8 +102,12 @@ class NewMatcher(BaseMatcher):
         # matched_kpts1 = self.rescale_coords(matched_kpts1, *img1_orig_shape, H1, W1)
 
         # RANSAC is handled in BaseMatcher.forward() which wraps this function, no need to filter inliers here
-        return matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1
-        # For detector-free methods (like LoFTR):
-        #   return matched_kpts0, matched_kpts1, None, None, None, None
+        return matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1, matched_confidences
+        # If the model does not provide per-match confidence:
+        #   return matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1, None
+        # For detector-free methods with confidence (like LoFTR):
+        #   return matched_kpts0, matched_kpts1, None, None, None, None, matched_confidences
+        # For detector-free methods without confidence:
+        #   return matched_kpts0, matched_kpts1, None, None, None, None, None
         # Some methods might even return no descriptors:
-        #   return matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, None, None
+        #   return matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, None, None, matched_confidences

--- a/vismatch/base_matcher.py
+++ b/vismatch/base_matcher.py
@@ -130,11 +130,9 @@ class BaseMatcher(torch.nn.Module):
         img1 = to_tensor_image(img1).to(self.device)
 
         # self._forward() is implemented by the children modules
-        matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1, *optional_outputs = self._forward(
-            img0, img1
+        matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1, matched_confidences = (
+            self._forward(img0, img1)
         )
-        assert len(optional_outputs) <= 1, f"_forward() should return 6 or 7 values, got {6 + len(optional_outputs)}"
-        matched_confidences = optional_outputs[0] if optional_outputs else None
 
         # Check that returned objects are of accepted types (nd.array, torch.tensor or None)
         self.check_types(matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1, matched_confidences)
@@ -250,12 +248,13 @@ class EnsembleMatcher(BaseMatcher):
         super().__init__(device, **kwargs)
         self.matchers = [get_matcher(name, device=device, **kwargs) for name in matcher_names]
 
-    def _forward(self, img0: torch.Tensor, img1: torch.Tensor) -> tuple[np.ndarray, np.ndarray, None, None, None, None]:
+    def _forward(
+        self, img0: torch.Tensor, img1: torch.Tensor
+    ) -> tuple[np.ndarray, np.ndarray, None, None, None, None, None]:
         all_matched_kpts0, all_matched_kpts1 = [], []
         for matcher in self.matchers:
-            matched_kpts0, matched_kpts1, _, _, _, _, *optional_outputs = matcher._forward(img0, img1)
-            assert len(optional_outputs) <= 1, f"{matcher.name}._forward() should return 6 or 7 values"
+            matched_kpts0, matched_kpts1, _, _, _, _, _ = matcher._forward(img0, img1)
             all_matched_kpts0.append(to_numpy(matched_kpts0))
             all_matched_kpts1.append(to_numpy(matched_kpts1))
         all_matched_kpts0, all_matched_kpts1 = np.concatenate(all_matched_kpts0), np.concatenate(all_matched_kpts1)
-        return all_matched_kpts0, all_matched_kpts1, None, None, None, None
+        return all_matched_kpts0, all_matched_kpts1, None, None, None, None, None

--- a/vismatch/base_matcher.py
+++ b/vismatch/base_matcher.py
@@ -119,8 +119,10 @@ class BaseMatcher(torch.nn.Module):
                 - all_desc1 (np.ndarray): (N1 x D) all descriptors from img1
                 - matched_kpts0 (np.ndarray): (N2 x 2) keypoints from img0 that match matched_kpts1 (pre-RANSAC)
                 - matched_kpts1 (np.ndarray): (N2 x 2) keypoints from img1 that match matched_kpts0 (pre-RANSAC)
+                - matched_confidences (np.ndarray | None): (N2,) per-match confidence scores, None if the matcher does not provide confidence. (pre-RANSAC)
                 - inlier_kpts0 (np.ndarray): (N3 x 2) filtered matched_kpts0 that fit the H model (post-RANSAC)
                 - inlier_kpts1 (np.ndarray): (N3 x 2) filtered matched_kpts1 that fit the H model (post-RANSAC)
+
         """
 
         # Take as input a pair of images (not a batch)
@@ -128,15 +130,20 @@ class BaseMatcher(torch.nn.Module):
         img1 = to_tensor_image(img1).to(self.device)
 
         # self._forward() is implemented by the children modules
-        matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1 = self._forward(img0, img1)
+        matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1, *optional_outputs = self._forward(
+            img0, img1
+        )
+        assert len(optional_outputs) <= 1, f"_forward() should return 6 or 7 values, got {6 + len(optional_outputs)}"
+        matched_confidences = optional_outputs[0] if optional_outputs else None
 
         # Check that returned objects are of accepted types (nd.array, torch.tensor or None)
-        self.check_types(matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1)
+        self.check_types(matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1, matched_confidences)
 
         # Convert torch tensors to numpy. None objects stay None
         matched_kpts0, matched_kpts1 = to_numpy(matched_kpts0), to_numpy(matched_kpts1)
         all_kpts0, all_kpts1 = to_numpy(all_kpts0), to_numpy(all_kpts1)
         all_desc0, all_desc1 = to_numpy(all_desc0), to_numpy(all_desc1)
+        matched_confidences = to_numpy(matched_confidences)
 
         # Some models might return kpts=None if no kpts are found. In this case, set an empty array with dim (0, 2)
         matched_kpts0 = self.get_empty_array_if_none(matched_kpts0)
@@ -148,7 +155,7 @@ class BaseMatcher(torch.nn.Module):
         all_desc1 = self.get_empty_array_if_none(all_desc1)
 
         # Check that shapes are correct and consistent
-        self.check_shapes(matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1)
+        self.check_shapes(matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1, matched_confidences)
 
         # Compute RANSAC to obtain the inliers and homography matrix
         H, inlier_kpts0, inlier_kpts1 = self.compute_ransac(matched_kpts0, matched_kpts1)
@@ -162,6 +169,7 @@ class BaseMatcher(torch.nn.Module):
             "all_desc1": all_desc1,
             "matched_kpts0": matched_kpts0,
             "matched_kpts1": matched_kpts1,
+            "matched_confidences": matched_confidences,
             "inlier_kpts0": inlier_kpts0,
             "inlier_kpts1": inlier_kpts1,
         }
@@ -188,7 +196,7 @@ class BaseMatcher(torch.nn.Module):
         return array
 
     @staticmethod
-    def check_types(matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1):
+    def check_types(matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1, matched_confidences=None):
         """Check that objects are of accepted types (nd.array, torch.tensor or None)"""
 
         def is_array_or_tensor_or_none(data) -> bool:
@@ -200,9 +208,12 @@ class BaseMatcher(torch.nn.Module):
         assert is_array_or_tensor_or_none(all_kpts1)
         assert is_array_or_tensor_or_none(all_desc0)
         assert is_array_or_tensor_or_none(all_desc1)
+        assert is_array_or_tensor_or_none(matched_confidences)
 
     @staticmethod
-    def check_shapes(matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1):
+    def check_shapes(
+        matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1, matched_confidences=None
+    ):
         """Check that objects have appropriate shapes, e.g. keypoints should have shape (N, 2)"""
 
         def check_kpts_shape(np_array) -> bool:
@@ -223,6 +234,13 @@ class BaseMatcher(torch.nn.Module):
             assert all_desc0.shape[0] == all_kpts0.shape[0], f"{all_desc0.shape[0]} != {all_kpts0.shape[0]}"
         if all_desc1.shape[0] != 0:
             assert all_desc1.shape[0] == all_kpts1.shape[0], f"{all_desc1.shape[0]} != {all_kpts1.shape[0]}"
+        if matched_confidences is not None:
+            assert matched_confidences.ndim == 1, (
+                f"matched_confidences shape should be (N,) but it is {matched_confidences.shape}"
+            )
+            assert matched_confidences.shape[0] == matched_kpts0.shape[0], (
+                f"{matched_confidences.shape[0]} != {matched_kpts0.shape[0]}"
+            )
 
 
 class EnsembleMatcher(BaseMatcher):
@@ -235,7 +253,8 @@ class EnsembleMatcher(BaseMatcher):
     def _forward(self, img0: torch.Tensor, img1: torch.Tensor) -> tuple[np.ndarray, np.ndarray, None, None, None, None]:
         all_matched_kpts0, all_matched_kpts1 = [], []
         for matcher in self.matchers:
-            matched_kpts0, matched_kpts1, _, _, _, _ = matcher._forward(img0, img1)
+            matched_kpts0, matched_kpts1, _, _, _, _, *optional_outputs = matcher._forward(img0, img1)
+            assert len(optional_outputs) <= 1, f"{matcher.name}._forward() should return 6 or 7 values"
             all_matched_kpts0.append(to_numpy(matched_kpts0))
             all_matched_kpts1.append(to_numpy(matched_kpts1))
         all_matched_kpts0, all_matched_kpts1 = np.concatenate(all_matched_kpts0), np.concatenate(all_matched_kpts1)

--- a/vismatch/im_models/aff_steerers.py
+++ b/vismatch/im_models/aff_steerers.py
@@ -140,4 +140,4 @@ class AffSteererMatcher(BaseMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, keypoints_0[0], keypoints_1[0], description_0[0], description_1[0]
+        return mkpts0, mkpts1, keypoints_0[0], keypoints_1[0], description_0[0], description_1[0], None

--- a/vismatch/im_models/aspanformer.py
+++ b/vismatch/im_models/aspanformer.py
@@ -68,8 +68,9 @@ class AspanformerMatcher(BaseMatcher):
 
         mkpts0 = batch["mkpts0_f"]
         mkpts1 = batch["mkpts1_f"]
+        mconf = batch["mconf"]
 
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf

--- a/vismatch/im_models/dedode.py
+++ b/vismatch/im_models/dedode.py
@@ -88,7 +88,7 @@ class DedodeMatcher(BaseMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, keypoints_0, keypoints_1, description_0.squeeze(0), description_1.squeeze(0)
+        return mkpts0, mkpts1, keypoints_0, keypoints_1, description_0.squeeze(0), description_1.squeeze(0), None
 
 
 class DedodeKorniaMatcher(BaseMatcher):
@@ -149,4 +149,4 @@ class DedodeKorniaMatcher(BaseMatcher):
             threshold=self.threshold,  # Increasing threshold -> fewer matches, fewer outliers
         )
 
-        return mkpts0, mkpts1, keypoints_0[0], keypoints_1[0], description_0[0], description_1[0]
+        return mkpts0, mkpts1, keypoints_0[0], keypoints_1[0], description_0[0], description_1[0], None

--- a/vismatch/im_models/duster.py
+++ b/vismatch/im_models/duster.py
@@ -93,7 +93,7 @@ class Dust3rMatcher(BaseMatcher):
 
         # return if there is no 3d points found on either one of the image
         if pts3d_list[0].shape[0] == 0 or pts3d_list[1].shape[0] == 0:
-            return np.empty((0, 2)), np.empty((0, 2)), None, None, None, None
+            return np.empty((0, 2)), np.empty((0, 2)), None, None, None, None, None
         reciprocal_in_P2, nn2_in_P1, _ = find_reciprocal_matches(*pts3d_list)
 
         mkpts1 = pts2d_list[1][reciprocal_in_P2]
@@ -105,4 +105,4 @@ class Dust3rMatcher(BaseMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, None

--- a/vismatch/im_models/edm.py
+++ b/vismatch/im_models/edm.py
@@ -56,9 +56,10 @@ class EDMMatcher(BaseMatcher):
 
         mkpts0 = batch["mkpts0_f"]
         mkpts1 = batch["mkpts1_f"]
+        mconf = batch["mconf"]
 
         H0, W0, H1, W1 = *img0.shape[-2:], *img1.shape[-2:]
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf

--- a/vismatch/im_models/efficient_loftr.py
+++ b/vismatch/im_models/efficient_loftr.py
@@ -52,9 +52,10 @@ class EfficientLoFTRMatcher(BaseMatcher):
 
         mkpts0 = batch["mkpts0_f"]
         mkpts1 = batch["mkpts1_f"]
+        mconf = batch["mconf"]
 
         H0, W0, H1, W1 = *img0.shape[-2:], *img1.shape[-2:]
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf

--- a/vismatch/im_models/gim.py
+++ b/vismatch/im_models/gim.py
@@ -63,7 +63,7 @@ class GIM_DKM(BaseMatcher):
 
         # b_ids = torch.where(mconf[None])[0]
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf
 
 
 class GIM_LightGlue(BaseMatcher):
@@ -182,6 +182,6 @@ class GIM_LightGlue(BaseMatcher):
         mkpts0 = torch.cat([kpts0[m_bids == b_id][matches[b_id][..., 0]] for b_id in range(bs)])
         mkpts1 = torch.cat([kpts1[m_bids == b_id][matches[b_id][..., 1]] for b_id in range(bs)])
         # b_ids = torch.cat([m_bids[m_bids == b_id][matches[b_id][..., 0]] for b_id in range(bs)])
-        # mconf = torch.cat(pred['scores'])
+        mconf = torch.cat(pred["scores"])
 
-        return mkpts0, mkpts1, kpts0, kpts1, desc0[0], desc1[0]
+        return mkpts0, mkpts1, kpts0, kpts1, desc0[0], desc1[0], mconf

--- a/vismatch/im_models/handcrafted.py
+++ b/vismatch/im_models/handcrafted.py
@@ -59,7 +59,7 @@ class HandcraftedBaseMatcher(BaseMatcher):
         keypoints_0 = np.array([(x.pt[0], x.pt[1]) for x in kp0])
         keypoints_1 = np.array([(x.pt[0], x.pt[1]) for x in kp1])
 
-        return mkpts0, mkpts1, keypoints_0, keypoints_1, des0, des1
+        return mkpts0, mkpts1, keypoints_0, keypoints_1, des0, des1, None
 
 
 class SiftNNMatcher(HandcraftedBaseMatcher):

--- a/vismatch/im_models/keypt2subpx.py
+++ b/vismatch/im_models/keypt2subpx.py
@@ -63,7 +63,9 @@ class Keypt2SubpxMatcher(BaseMatcher):
             return self.matcher.get_scoremap(idx)
 
     def _forward(self, img0, img1):
-        mkpts0, mkpts1, keypoints0, keypoints1, descriptors0, descriptors1 = self.matcher._forward(img0, img1)
+        mkpts0, mkpts1, keypoints0, keypoints1, descriptors0, descriptors1, matched_confidences = self.matcher._forward(
+            img0, img1
+        )
         if len(mkpts0):  # only run subpx refinement if kpts are found
             matching_idxs0, matching_idxs1 = (
                 self.get_match_idxs(mkpts0, keypoints0),
@@ -82,7 +84,7 @@ class Keypt2SubpxMatcher(BaseMatcher):
                 scores0,
                 scores1,
             )
-        return mkpts0, mkpts1, keypoints0, keypoints1, descriptors0, descriptors1
+        return mkpts0, mkpts1, keypoints0, keypoints1, descriptors0, descriptors1, matched_confidences
 
 
 class SuperPointDense(BaseMatcher):
@@ -151,4 +153,4 @@ class SuperPointDense(BaseMatcher):
 
         mkpts0, mkpts1 = kpts0[matches[..., 0]], kpts1[matches[..., 1]]
 
-        return mkpts0, mkpts1, kpts0, kpts1, desc0, desc1
+        return mkpts0, mkpts1, kpts0, kpts1, desc0, desc1, None

--- a/vismatch/im_models/kornia.py
+++ b/vismatch/im_models/kornia.py
@@ -69,4 +69,4 @@ class DeDoDeLightGlue(BaseMatcher):
         mkpts0 = kpts0.squeeze()[matching_idxs[:, 0]]
         mkpts1 = kpts1.squeeze()[matching_idxs[:, 1]]
 
-        return mkpts0, mkpts1, kpts0[0], kpts1[0], desc0[0], desc1[0]
+        return mkpts0, mkpts1, kpts0[0], kpts1[0], desc0[0], desc1[0], None

--- a/vismatch/im_models/liftfeat.py
+++ b/vismatch/im_models/liftfeat.py
@@ -41,4 +41,5 @@ class LiftFeatMatcher(BaseMatcher):
             None,  # keypoints_1
             None,  # desc0
             None,  # desc1
+            None,  # matched_confidences
         )

--- a/vismatch/im_models/lightglue.py
+++ b/vismatch/im_models/lightglue.py
@@ -32,8 +32,9 @@ class LightGlueBase(BaseMatcher):
         desc1 = feats1["descriptors"]
 
         mkpts0, mkpts1 = kpts0[matches[..., 0]], kpts1[matches[..., 1]]
+        mconf = matches01.get("scores")
 
-        return mkpts0, mkpts1, kpts0, kpts1, desc0, desc1
+        return mkpts0, mkpts1, kpts0, kpts1, desc0, desc1, mconf
 
 
 class SiftLightGlue(LightGlueBase):

--- a/vismatch/im_models/lisrd.py
+++ b/vismatch/im_models/lisrd.py
@@ -99,5 +99,6 @@ class LISRDMatcher(BaseMatcher):
             keypoints1,
             None,  # desc0,
             None,  # desc1,
+            None,  # matched_confidences
         )
         # lisrd has N x 4 x D dimensional descriptors, inconsistent with other methods, hence return None as descs

--- a/vismatch/im_models/loftr.py
+++ b/vismatch/im_models/loftr.py
@@ -18,6 +18,6 @@ class LoftrMatcher(BaseMatcher):
         batch = {"image0": img0, "image1": img1}
 
         output = self.model(batch)
-        mkpts0, mkpts1 = output["keypoints0"], output["keypoints1"]
+        mkpts0, mkpts1, mconf = output["keypoints0"], output["keypoints1"], output["confidence"]
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf

--- a/vismatch/im_models/loma.py
+++ b/vismatch/im_models/loma.py
@@ -70,9 +70,11 @@ class LoMaMatcher(BaseMatcher):
         kpts1, desc1, _, _ = self.matcher.detect_and_describe(img1, self.max_num_keypoints)
 
         scores = self.matcher(kpts0, kpts1, desc0, desc1)["scores"]
-        m0, _, _, _ = filter_matches(scores, self.matcher.cfg.filter_threshold)
+        m0, _, mscores0, _ = filter_matches(scores, self.matcher.cfg.filter_threshold)
 
+        # LoMa returns bfloat16 conf values. for numpy to convert this we need to cast it to float.
         valid = m0[0] > -1
+        matched_conf = mscores0[0][valid].float() 
         matched_kpts0 = to_pixel_coords(kpts0[0][torch.where(valid)[0]], H0, W0)
         matched_kpts1 = to_pixel_coords(kpts1[0][m0[0][valid]], H1, W1)
 
@@ -91,4 +93,4 @@ class LoMaMatcher(BaseMatcher):
         all_kpts0 -= offset
         all_kpts1 -= offset
 
-        return matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, desc0[0], desc1[0]
+        return matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, desc0[0], desc1[0], matched_conf

--- a/vismatch/im_models/master.py
+++ b/vismatch/im_models/master.py
@@ -107,4 +107,4 @@ class Mast3rMatcher(BaseMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, None

--- a/vismatch/im_models/matchanything.py
+++ b/vismatch/im_models/matchanything.py
@@ -147,12 +147,13 @@ class MatchAnythingMatcher(BaseMatcher):
 
         mkpts0 = batch["mkpts0_f"].detach().cpu()
         mkpts1 = batch["mkpts1_f"].detach().cpu()
+        mconf = batch["mconf"].detach().cpu() if "mconf" in batch else None
 
         if self.variant == "eloftr":
             mkpts0 *= torch.tensor(img0_scale)[[1, 0]]
             mkpts1 *= torch.tensor(img1_scale)[[1, 0]]
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf
 
 
 # Custom resize logic from MatchAnything to preserve padding/masks expected by the upstream config.

--- a/vismatch/im_models/matchformer.py
+++ b/vismatch/im_models/matchformer.py
@@ -54,8 +54,9 @@ class MatchformerMatcher(BaseMatcher):
 
         mkpts0 = batch["mkpts0_f"]
         mkpts1 = batch["mkpts1_f"]
+        mconf = batch["mconf"]
 
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf

--- a/vismatch/im_models/matching_toolbox.py
+++ b/vismatch/im_models/matching_toolbox.py
@@ -69,11 +69,11 @@ class Patch2pixMatcher(BaseMatcher):
         if len(pos_ids) > 0:
             coarse_matches = coarse_matches[pos_ids]
             matches = fine_matches[pos_ids]
-            # scores = fine_scores[pos_ids]
+            scores = fine_scores[pos_ids]
         else:
             # Simply take all matches for this case
             matches = fine_matches
-            # scores = fine_scores
+            scores = fine_scores
 
         mkpts0 = matches[:, :2]
         mkpts1 = matches[:, 2:4]
@@ -82,7 +82,7 @@ class Patch2pixMatcher(BaseMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, scores
 
 
 class SuperGlueMatcher(BaseMatcher):
@@ -120,11 +120,11 @@ class SuperGlueMatcher(BaseMatcher):
         img0_gray = self.to_gray(img0).unsqueeze(0).to(self.device)
         img1_gray = self.to_gray(img1).unsqueeze(0).to(self.device)
 
-        matches, kpts0, kpts1, _ = self.matcher.match_inputs_(img0_gray, img1_gray)
+        matches, kpts0, kpts1, scores = self.matcher.match_inputs_(img0_gray, img1_gray)
         mkpts0 = matches[:, :2]
         mkpts1 = matches[:, 2:4]
 
-        return mkpts0, mkpts1, kpts0, kpts1, None, None
+        return mkpts0, mkpts1, kpts0, kpts1, None, None, scores
 
 
 class R2D2Matcher(BaseMatcher):
@@ -165,7 +165,7 @@ class R2D2Matcher(BaseMatcher):
         mkpts0 = kpts0[match_ids[:, 0], :2].cpu().numpy()
         mkpts1 = kpts1[match_ids[:, 1], :2].cpu().numpy()
 
-        return mkpts0, mkpts1, kpts0[:, :2], kpts1[:, :2], desc0, desc1
+        return mkpts0, mkpts1, kpts0[:, :2], kpts1[:, :2], desc0, desc1, scores
 
 
 class D2netMatcher(BaseMatcher):
@@ -203,11 +203,11 @@ class D2netMatcher(BaseMatcher):
         kpts0, desc0 = self.model.extract_features(img0)
         kpts1, desc1 = self.model.extract_features(img1)
 
-        match_ids, _ = self.model.mutual_nn_match(desc0, desc1, threshold=self.match_threshold)
+        match_ids, scores = self.model.mutual_nn_match(desc0, desc1, threshold=self.match_threshold)
         mkpts0 = kpts0[match_ids[:, 0], :2]
         mkpts1 = kpts1[match_ids[:, 1], :2]
 
-        return mkpts0, mkpts1, kpts0, kpts1, desc0, desc1
+        return mkpts0, mkpts1, kpts0, kpts1, desc0, desc1, scores
 
 
 class DogAffHardNNMatcher(BaseMatcher):
@@ -234,8 +234,8 @@ class DogAffHardNNMatcher(BaseMatcher):
         img0 = self.tensor_to_numpy_int(img0)
         img1 = self.tensor_to_numpy_int(img1)
 
-        matches, _, _, _ = self.model.match_inputs_(img0, img1)
+        matches, _, _, scores = self.model.match_inputs_(img0, img1)
         mkpts0 = matches[:, :2]
         mkpts1 = matches[:, 2:4]
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, scores.reshape(-1)

--- a/vismatch/im_models/minima.py
+++ b/vismatch/im_models/minima.py
@@ -87,7 +87,7 @@ class MINIMALoFTRMatcher(MINIMAMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, None
 
 
 class MINIMARomaMatcher(MINIMAMatcher):
@@ -162,4 +162,4 @@ class MINIMAXoFTRMatcher(MINIMAMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, None

--- a/vismatch/im_models/minima.py
+++ b/vismatch/im_models/minima.py
@@ -46,12 +46,13 @@ class MINIMASuperpointLightGlueMatcher(MINIMAMatcher):
 
         mkpts0 = batch["keypoints0"]
         mkpts1 = batch["keypoints1"]
+        mconf  = batch["matching_scores"]
 
         H0, W0, H1, W1 = *img0.shape[-2:], *img1.shape[-2:]
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf
 
 
 class MINIMALoFTRMatcher(MINIMAMatcher):
@@ -125,7 +126,7 @@ class MINIMARomaMatcher(MINIMAMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf
 
 
 class MINIMAXoFTRMatcher(MINIMAMatcher):

--- a/vismatch/im_models/omniglue.py
+++ b/vismatch/im_models/omniglue.py
@@ -89,4 +89,4 @@ class OmniglueMatcher(BaseMatcher):
             mkpts1 = mkpts1[keep_idx]
             match_conf = match_conf[keep_idx]
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, None

--- a/vismatch/im_models/rdd.py
+++ b/vismatch/im_models/rdd.py
@@ -101,7 +101,7 @@ class RDDMatcher(BaseMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, keypoints_0, keypoints_1, desc0, desc1
+        return mkpts0, mkpts1, keypoints_0, keypoints_1, desc0, desc1, conf
 
 
 class _rdd_lightglue_wrapper(LightGlue):
@@ -183,14 +183,14 @@ class RDD_LightGlueMatcher(RDDMatcher):
         valid_mask = conf > self.thresh
         mkpts0 = mkpts0[valid_mask]
         mkpts1 = mkpts1[valid_mask]
-        # conf = conf[valid_mask]
+        conf = conf[valid_mask]
 
         # if we had to resize the img to divisible, then rescale the kpts back to input img size
         H0, W0, H1, W1 = *img0.shape[-2:], *img1.shape[-2:]
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, keypoints_0, keypoints_1, desc0, desc1
+        return mkpts0, mkpts1, keypoints_0, keypoints_1, desc0, desc1, conf
 
 
 class RDD_ThirdPartyMatcher(RDDMatcher):
@@ -247,4 +247,4 @@ class RDD_ThirdPartyMatcher(RDDMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, keypoints_0, keypoints_1, desc0, desc1
+        return mkpts0, mkpts1, keypoints_0, keypoints_1, desc0, desc1, conf

--- a/vismatch/im_models/ripe.py
+++ b/vismatch/im_models/ripe.py
@@ -52,4 +52,4 @@ class RIPEMatcher(BaseMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, keypoints_1, keypoints_1, desc0, desc1
+        return mkpts0, mkpts1, keypoints_1, keypoints_1, desc0, desc1, None

--- a/vismatch/im_models/roma.py
+++ b/vismatch/im_models/roma.py
@@ -64,7 +64,7 @@ class RomaMatcher(BaseMatcher):
         matches, certainty = self.roma_model.sample(warp, certainty, num=self.max_keypoints)
         mkpts0, mkpts1 = self.roma_model.to_pixel_coordinates(matches, h0, w0, h1, w1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, certainty
 
 
 class TinyRomaMatcher(BaseMatcher):
@@ -91,4 +91,4 @@ class TinyRomaMatcher(BaseMatcher):
         matches, certainty = self.roma_model.sample(warp, certainty, num=self.max_keypoints)
         mkpts0, mkpts1 = self.roma_model.to_pixel_coordinates(matches, h0, w0, h1, w1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, certainty

--- a/vismatch/im_models/romav2.py
+++ b/vismatch/im_models/romav2.py
@@ -59,4 +59,4 @@ class RoMaV2Matcher(BaseMatcher):
 
         mkpts0, mkpts1 = self.romav2_model.to_pixel_coordinates(matches, h0, w0, h1, w1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, confidence

--- a/vismatch/im_models/se2loftr.py
+++ b/vismatch/im_models/se2loftr.py
@@ -63,9 +63,10 @@ class Se2LoFTRMatcher(BaseMatcher):
 
         mkpts0 = batch["mkpts0_f"]
         mkpts1 = batch["mkpts1_f"]
+        mconf = batch["mconf"]
 
         H0, W0, H1, W1 = *img0.shape[-2:], *img1.shape[-2:]
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf

--- a/vismatch/im_models/silk.py
+++ b/vismatch/im_models/silk.py
@@ -402,4 +402,4 @@ class SilkMatcher(BaseMatcher):
         all_kpts0 = kpts0[:, :2][:, [1, 0]] if len(kpts0) > 0 else torch.zeros((0, 2), device=self.device)
         all_kpts1 = kpts1[:, :2][:, [1, 0]] if len(kpts1) > 0 else torch.zeros((0, 2), device=self.device)
 
-        return mkpts0, mkpts1, all_kpts0, all_kpts1, desc0, desc1
+        return mkpts0, mkpts1, all_kpts0, all_kpts1, desc0, desc1, None

--- a/vismatch/im_models/sphereglue.py
+++ b/vismatch/im_models/sphereglue.py
@@ -74,7 +74,7 @@ class SphereGlueBase(BaseMatcher):
         mkpts0 = kpts0[kpts0_idx]
         mkpts1 = kpts1[kpts1_idx]
 
-        return mkpts0, mkpts1, kpts0, kpts1, desc0, desc1
+        return mkpts0, mkpts1, kpts0, kpts1, desc0, desc1, None
 
 
 class SiftSphereGlue(SphereGlueBase):

--- a/vismatch/im_models/steerers.py
+++ b/vismatch/im_models/steerers.py
@@ -137,4 +137,4 @@ class SteererMatcher(BaseMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, keypoints_0[0], keypoints_1[0], description_0[0], description_1[0]
+        return mkpts0, mkpts1, keypoints_0[0], keypoints_1[0], description_0[0], description_1[0], None

--- a/vismatch/im_models/topicfm.py
+++ b/vismatch/im_models/topicfm.py
@@ -83,9 +83,10 @@ class TopicFMMatcher(BaseMatcher):
         # Extract matched keypoints
         mkpts0 = data["mkpts0_f"]
         mkpts1 = data["mkpts1_f"]
+        mconf = data["mconf"]
 
         H0, W0, H1, W1 = *img0.shape[-2:], *img1.shape[-2:]
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf

--- a/vismatch/im_models/ufm.py
+++ b/vismatch/im_models/ufm.py
@@ -57,4 +57,4 @@ class UFMMatcher(BaseMatcher):
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, confidences

--- a/vismatch/im_models/xfeat.py
+++ b/vismatch/im_models/xfeat.py
@@ -51,6 +51,7 @@ class xFeatMatcher(BaseMatcher):
                 matches.append(self.model.refine_matches(output0, output1, matches=idxs_list, batch_idx=batch_idx))
 
             mkpts0, mkpts1 = matches if batch_size > 1 else (matches[0][:, :2], matches[0][:, 2:])
+            matched_confidences = None
 
         elif self.mode in ["sparse", "lighterglue"]:
             output0 = self.model.detectAndCompute(img0, top_k=self.max_num_keypoints)[0]
@@ -61,10 +62,16 @@ class xFeatMatcher(BaseMatcher):
                 output0.update({"image_size": (img0.shape[-1], img0.shape[-2])})
                 output1.update({"image_size": (img1.shape[-1], img1.shape[-2])})
 
-                mkpts0, mkpts1 = self.model.match_lighterglue(output0, output1)
+                pred = self.model.match_lighterglue(output0, output1)
+                if len(pred) == 3:
+                    mkpts0, mkpts1, matched_confidences = pred
+                else:
+                    mkpts0, mkpts1 = pred
+                    matched_confidences = None
             else:  # sparse
                 idxs0, idxs1 = self.model.match(output0["descriptors"], output1["descriptors"], min_cossim=-1)
                 mkpts0, mkpts1 = output0["keypoints"][idxs0], output1["keypoints"][idxs1]
+                matched_confidences = None
         else:
             raise ValueError(f'unsupported mode for xfeat: {self.mode}. Must choose from ["sparse", "semi-dense"]')
 
@@ -75,4 +82,5 @@ class xFeatMatcher(BaseMatcher):
             output1["keypoints"].squeeze(),
             output0["descriptors"].squeeze(),
             output1["descriptors"].squeeze(),
+            matched_confidences,
         )

--- a/vismatch/im_models/xfeat_steerers.py
+++ b/vismatch/im_models/xfeat_steerers.py
@@ -160,4 +160,5 @@ class xFeatSteerersMatcher(BaseMatcher):
             output1["keypoints"].squeeze(),
             output0["descriptors"].squeeze(),
             output1["descriptors"].squeeze(),
+            None,
         )

--- a/vismatch/im_models/xoftr.py
+++ b/vismatch/im_models/xoftr.py
@@ -63,9 +63,10 @@ class XoFTRMatcher(BaseMatcher):
 
         mkpts0 = batch["mkpts0_f"]
         mkpts1 = batch["mkpts1_f"]
+        mconf = batch["mconf_f"]
 
         H0, W0, H1, W1 = *img0.shape[-2:], *img1.shape[-2:]
         mkpts0 = self.rescale_coords(mkpts0, *img0_orig_shape, H0, W0)
         mkpts1 = self.rescale_coords(mkpts1, *img1_orig_shape, H1, W1)
 
-        return mkpts0, mkpts1, None, None, None, None
+        return mkpts0, mkpts1, None, None, None, None, mconf

--- a/vismatch/im_models/zippypoint.py
+++ b/vismatch/im_models/zippypoint.py
@@ -99,11 +99,11 @@ class ZippyPointMatcher(BaseMatcher):
         all_kpts1, all_desc1, desc1 = self.infer(img1)
 
         if desc0.shape[1] == 0 or desc1.shape[1] == 0:
-            return None, None, all_kpts0, all_kpts1, all_desc0, all_desc1
+            return None, None, all_kpts0, all_kpts1, all_desc0, all_desc1, None
 
         matches = self.matching({"descriptors0": desc0, "descriptors1": desc1})["matches0"][0].numpy()
         valid = matches > -1
         matched_kpts0 = all_kpts0[valid]
         matched_kpts1 = all_kpts1[matches[valid]]
 
-        return matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1
+        return matched_kpts0, matched_kpts1, all_kpts0, all_kpts1, all_desc0, all_desc1, None


### PR DESCRIPTION
This pull request adds optional per-match confidence support to the matcher API while preserving compatibility with existing matchers. #67 

## Changes

* Extends `BaseMatcher._forward()` to accept either the existing six-value return tuple or a seven-value tuple that includes `matched_confidences`.
* Adds `matched_confidences` to matcher results.
* Returns `None` when a matcher does not provide per-match confidence values.
* Validates confidence output when present: it must be a one-dimensional array aligned with `matched_kpts0` and `matched_kpts1`.
* Updates selected model wrappers that already expose true per-match scores.
* Updates the documentation and template matcher guidance.
* Adds lightweight tests covering:

  * legacy six-value matchers,
  * confidence-returning matchers, and
  * invalid confidence array shapes.

This enables confidence-aware downstream consumers without requiring changes to existing matcher implementations.

## Matchers Updated to Return Per-Match Confidence
* LoFTR, ELoFTR, SE2LoFTR, XoFTR, ASpanFormer, MatchFormer, EDM
* TopicFM, TopicFM+, MatchAnything-ELoFTR, MatchAnything-RoMa
* RoMa, Tiny-RoMa, RoMaV2
* MINIMA, MINIMA-SuperPoint-LightGlue, MINIMA-RoMa, MINIMA-RoMa-Tiny
* SIFT-LightGlue, SuperPoint-LightGlue, DISK-LightGlue, ALIKED-LightGlue
* DoGHardNet-LightGlue, GIM-LightGlue, GIM-DKM, UFM, RDD-LightGlue
* Patch2Pix, SuperGlue, R2D2, D2Net, DoGHardNet-NN
* LoMa, LoMa-R, XFeat-LightGlue