### PR TITLE
Fix ransac_conf being silently ignored in cv2.findHomography

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -51,7 +51,7 @@
    "source": [
     "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
     "print(f\"Using device: {device}\")\n",
-    "ransac_kwargs = {\"ransac_reproj_thresh\": 3, \"ransac_conf\": 0.95, \"ransac_iters\": 2000}  # optional ransac params\n",
+    "ransac_kwargs = {\"ransac_reproj_thresh\": 3, \"ransac_conf\": 0.995, \"ransac_iters\": 2000}  # optional ransac params\n",
     "matcher = get_matcher([\"superpoint-lightglue\"], device=device, **ransac_kwargs)  # try an ensemble!"
    ]
   },

--- a/vismatch/base_matcher.py
+++ b/vismatch/base_matcher.py
@@ -37,7 +37,7 @@ class BaseMatcher(torch.nn.Module):
 
         # OpenCV default ransac params
         self.ransac_iters: int = kwargs.get("ransac_iters", 2000)
-        self.ransac_conf: float = kwargs.get("ransac_conf", 0.95)
+        self.ransac_conf: float = kwargs.get("ransac_conf", 0.995)
         self.ransac_reproj_thresh: float = kwargs.get("ransac_reproj_thresh", 3)
 
     @property
@@ -100,10 +100,10 @@ class BaseMatcher(torch.nn.Module):
         H, inliers_mask = cv2.findHomography(
             matched_kpts0,
             matched_kpts1,
-            cv2.USAC_MAGSAC,
-            self.ransac_reproj_thresh,
-            self.ransac_conf,
-            self.ransac_iters,
+            method=cv2.USAC_MAGSAC,
+            ransacReprojThreshold=self.ransac_reproj_thresh,
+            maxIters=self.ransac_iters,
+            confidence=self.ransac_conf,
         )
         inliers_mask = inliers_mask[:, 0].astype(bool)
         inlier_kpts0 = matched_kpts0[inliers_mask]


### PR DESCRIPTION
Hey, cool library, this is my first PR to this project. Claude caught this bug while trying to extract some feature matching code from this library to use in my project.

The issue is that cv2.findHomography was called with positional arguments, which put ransac_conf in the mask slot. As a result, the confidence knob was dead and OpenCV silently used its default of 0.995 no matter what was passed.

 **This PR switches the cv2 homography call to use keyword arguments**

The ransac_conf default is also bumped from 0.95 to 0.995. This was the actual conf value that was used in previous versions of the library, so the usage should stay the same/reproducible. The difference now is that users who explicitly set ransac_conf value, will now actually use it, instead of it being silently unused.

Looking forward to your feedback regarding this PR.